### PR TITLE
Add _get_comp_words_by_ref

### DIFF
--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -441,8 +441,6 @@ _yarn_yarn() {
     local args counter
     __yarn_count_args
 
-    _get_comp_words_by_ref cur prev words cword
-
     case "$cur" in
         -*)
             COMPREPLY=( $( compgen -W "${global_flags[*]}" -- "$cur" ) )
@@ -534,6 +532,7 @@ _yarn() {
     )
 
     COMPREPLY=()
+    _get_comp_words_by_ref cur prev words cword
     if command -v _init_completion >/dev/null 2>&1; then
         _init_completion || return
     fi

--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -18,11 +18,12 @@
 #
 # @param $1 parentField  The first-level property of interest.
 #
+
 __yarn_get_package_fields() {
     local parentField="$1"
     local package
     local fields
-    
+
     package="$(pwd)/package.json"
     [ ! -e "$package" ] && return
 
@@ -123,7 +124,7 @@ _yarn_config() {
         version-git-tag
         version-tag-prefix
     )
-    
+
     case "$prev" in
         get|delete)
             COMPREPLY=( $( compgen -W "${known_keys[*]}" -- "$cur" ) )
@@ -334,7 +335,7 @@ _yarn_publish() {
             return
             ;;
     esac
-    
+
     __yarn_filedir
 }
 
@@ -439,6 +440,8 @@ _yarn_why() {
 _yarn_yarn() {
     local args counter
     __yarn_count_args
+
+    _get_comp_words_by_ref cur prev words cword
 
     case "$cur" in
         -*)


### PR DESCRIPTION
This patch fixed completion on my MacOS machine. Previously it would just list the available commands, but not actually complete them based on the current fragment. Since I'm the sort that hammers tab, this is what I was looking for. I haven't done that many bash completion functions so I'm not certain about how cross-platform this solution is.

Sorry about the whitespace changes, my editor does that by default.