### PR TITLE
Fix: double-quoted operand

### DIFF
--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -399,7 +399,7 @@ _yarn_config() {
 			case "$cur" in
 				-*) ;;
 				*)
-					if [[ $prev == @(get|delete) ]]; then
+					if [[ $prev == "@(get|delete)" ]]; then
 						COMPREPLY=($(compgen -W "${known_keys[*]}" -- "$cur"))
 						return 0
 					fi


### PR DESCRIPTION
Non-double-quoted operand at line 402 caused error on Bash 5.0.3 / macOS 10.14.3.

```terminal
bash: /usr/local/Cellar/git/2.21.0/etc/bash_completion.d/yarn-completion.bash: line 402: syntax error in conditional expression: unexpected token `('
bash: /usr/local/Cellar/git/2.21.0/etc/bash_completion.d/yarn-completion.bash: line 402: syntax error near `@(g'
bash: /usr/local/Cellar/git/2.21.0/etc/bash_completion.d/yarn-completion.bash: line 402: `                                      if [[ $prev == @(get|delete) ]]; then'
```