### PR TITLE
Add --install option to init

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarn-completion",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "repository": "https://github.com/dsifford/yarn-completion.git",
   "description": "shell autocompletion for yarn",
   "author": "Derek P Sifford <dereksifford@gmail.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yarn-completion",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "repository": "https://github.com/dsifford/yarn-completion.git",
   "description": "shell autocompletion for yarn",
   "author": "Derek P Sifford <dereksifford@gmail.com>",

--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -1,7 +1,7 @@
 # shellcheck shell=bash disable=2207
 # vim: set fdm=syntax fdl=0:
 #
-# Version: 0.15.1
+# Version: 0.16.0
 # Yarn Version: 1.21.1
 #
 # bash completion for Yarn (https://github.com/yarnpkg/yarn)

--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -1,8 +1,8 @@
 # shellcheck shell=bash disable=2207
 # vim: set fdm=syntax fdl=0:
 #
-# Version: 0.15.0
-# Yarn Version: 1.19.1
+# Version: 0.15.1
+# Yarn Version: 1.21.1
 #
 # bash completion for Yarn (https://github.com/yarnpkg/yarn)
 #
@@ -579,6 +579,7 @@ _yarn_init() {
 	flags=(
 		--yes -y
 		--private -p
+		--install -i
 	)
 	return 1
 }


### PR DESCRIPTION
The `init` command has a new option in `v1.21.1`.
```
-i, --install <value>               install a specific Yarn release
```
I've bumped the version of the package. Let me know if I should revert that.