### PR TITLE
Fix column escape in args (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,16 +48,6 @@ $ curl -o "${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash
 
 **No**. Bash 3 is now 9 years outdated (at time of writing). There is no conceivable reason why anybody would or should still be using bash 3. Upgrade to the latest version of bash.
 
-> Completion fails for run scripts that contains a colon.
-
-This is a feature of bash. Enable `menu-complete` in your `~/.inputrc` if you'd prefer a more seamless experience.
-
-```
-# Cycle through completions, rather than dumping all options
-TAB:       menu-complete
-"\e[Z":    menu-complete-backward
-```
-
 ## License
 
 MIT

--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -1025,8 +1025,6 @@ _yarn() {
 	shopt -s extglob
 	set -o pipefail
 
-	declare COMP_WORDBREAKS=$' \t\n"\'><=;|&(:'
-
 	declare cur cmd prev
 	declare -a words
 	declare -i cword counter=1 depth=1
@@ -1188,17 +1186,19 @@ _yarn() {
 	declare -a flags=()
 
 	COMPREPLY=()
-	if command -v _init_completion > /dev/null; then
+	if command -v _get_comp_words_by_ref > /dev/null; then
+		_get_comp_words_by_ref -n = -n @ -n : cur prev words cword
+	elif command -v _init_completion > /dev/null; then
 		_init_completion
-	else
-		if command -v _get_comp_words_by_ref > /dev/null; then
-			_get_comp_words_by_ref cur prev words cword
-		fi
 	fi
 
 	__yarn_get_command -d 1
 
 	__yarn_flag_args || "_yarn_${cmd//-/_}" 2> /dev/null || __yarn_fallback
+
+	if command -v __ltrim_colon_completions > /dev/null; then
+		__ltrim_colon_completions "$cur"
+	fi
 }
 
 if [[ ${BASH_VERSINFO[0]} -ge 4 && ${BASH_VERSINFO[1]} -ge 4 ]]; then


### PR DESCRIPTION
- use same char escapes as npm (see `npm completion` output)
- avoid COMP_WORDBREAKS override