### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 To enable on-demand completion loading, download the completion file to the predefined bash-completion user directory.
 
 ```sh
-$ curl -o "${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/yarn" https://raw.githubusercontent.com/dsifford/yarn-completion/master/yarn-completion.bash
+$ mkdir -p "${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/" && curl -o "${BASH_COMPLETION_USER_DIR:-${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion}/completions/yarn" https://raw.githubusercontent.com/dsifford/yarn-completion/master/yarn-completion.bash
 ```
 
 ### Installation on macOS with Homebrew


### PR DESCRIPTION
When I tried the suggested install command I was missing the directory to hold the user specific bash completion files. This PR adds an `mkdir -p` invocation to the installation instructions, so that they'll work even if the directory is not present.