### PR TITLE
Small adjustment in order to make yarn-completion.bash compatible to zsh

### DIFF
--- a/yarn-completion.bash
+++ b/yarn-completion.bash
@@ -1015,14 +1015,17 @@ _yarn_yarn() {
 }
 
 _yarn() {
-	# shellcheck disable=SC2064
-	trap "
-		PWD=$PWD
-		$(shopt -p extglob)
-		set +o pipefail
-	" RETURN
+	if [[ "$SHELL" != "/bin/zsh" && "$SHELL" != "/usr/bin/zsh" ]]; then
+		# shellcheck disable=SC2064
+		trap "
+			PWD=$PWD
+			$(shopt -p extglob)
+			set +o pipefail
+		" RETURN
 
-	shopt -s extglob
+		shopt -s extglob
+	fi
+
 	set -o pipefail
 
 	declare cur cmd prev


### PR DESCRIPTION
Works for me on zsh 5.8.1 (x86_64-ubuntu-linux-gnu) when adding the following to ~/.zshrc:
```sh
source yarn-completion.bash
```